### PR TITLE
Only run code-push on the canonical repo

### DIFF
--- a/.github/workflows/on-code-push.yml
+++ b/.github/workflows/on-code-push.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   job:
+    if: github.repository == 'aerius/tools'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Guard the code-push workflow so it only runs on aerius/tools.

---
<details>
<summary>LLM-generated technical summary</summary>

`code-push` builds and deploys a `-SNAPSHOT` of `tools` to the internal Nexus, using the `NEXUS_*` secrets. Forks do not have those secrets, so a fork push that matches the workflow's branch filter fails on the deploy step with a 401.

Since this PR was opened, #28 renamed `on-push.yml` to `on-code-push.yml` and already added the branch filter (`main` and `**_fixes`), which was the other half of the original change. That part is dropped here.

What remains is `if: github.repository == 'aerius/tools'` on the job. The branch filter stops fork pushes on ordinary feature branches, but a fork pushing to its own `main` or to any `*_fixes` branch still triggers the workflow and still fails. The repository guard covers that case.

Note: `on-new-tag.yml` has the same exposure (`NEXUS_*` secrets, triggers on `tags: '**'`), but is left alone here.
</details>